### PR TITLE
Fix open legacy crashes and macOS packaging metadata

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -103,6 +103,7 @@ cat > "${APP_DIR}/Contents/Info.plist" <<PLIST
   <key>CFBundleVersion</key><string>${new_version}</string>
   <key>LSMinimumSystemVersion</key><string>11.0</string>
   <key>NSHighResolutionCapable</key><true/>
+  <key>NSRequiresAquaSystemAppearance</key><false/>
 </dict>
 </plist>
 PLIST

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,25 @@ target_link_libraries(MachOExplorer PRIVATE
     Qt${QT_VERSION_MAJOR}::Network
 )
 
+if(APPLE)
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/libmoex/ver.h"
+        MOEX_VER_LINE REGEX "^#define LIBMOEX_VERSION \".*\"$")
+    set(MOEX_APP_VERSION "0.0.0")
+    if(MOEX_VER_LINE)
+        string(REGEX REPLACE ".*\"([0-9]+\\.[0-9]+\\.[0-9]+)\".*" "\\1"
+            MOEX_APP_VERSION "${MOEX_VER_LINE}")
+    endif()
+
+    set_target_properties(MachOExplorer PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_BUNDLE_NAME "MachOExplorer"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.everettjf.machoexplorer"
+        MACOSX_BUNDLE_BUNDLE_VERSION "${MOEX_APP_VERSION}"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "${MOEX_APP_VERSION}"
+        MACOSX_BUNDLE_INFO_STRING "MachOExplorer ${MOEX_APP_VERSION}"
+    )
+endif()
+
 if(CAPSTONE_INCLUDE_DIR AND CAPSTONE_LIBRARY)
     message(STATUS "Capstone enabled: ${CAPSTONE_LIBRARY}")
     target_compile_definitions(MachOExplorer PRIVATE MOEX_HAS_CAPSTONE=1)

--- a/src/libmoex/node/FatHeader.cpp
+++ b/src/libmoex/node/FatHeader.cpp
@@ -4,31 +4,54 @@
 //
 #include "FatHeader.h"
 #include "Util.h"
+#include <cstring>
 
 MOEX_NAMESPACE_BEGIN
 
 
 
 void FatArch::Init(void *offset, NodeContextPtr &ctx) {
-    NodeData::Init(offset,ctx);
+    offset_ = static_cast<qv_fat_arch *>(offset);
+    ctx_ = ctx;
 
-    if(swap_){
-        qv_swap_fat_arch(&data_,1,NX_LittleEndian);
+    uint64_t object_offset = 0;
+    uint64_t object_size = 0;
+    if (is_fat64_) {
+        std::memcpy(&raw_arch64_, offset, sizeof(raw_arch64_));
+        if (swap_) {
+            qv_swap_fat_arch_64(&raw_arch64_, 1, NX_LittleEndian);
+        }
+        object_offset = raw_arch64_.offset;
+        object_size = raw_arch64_.size;
+    } else {
+        std::memcpy(&raw_arch32_, offset, sizeof(raw_arch32_));
+        if (swap_) {
+            qv_swap_fat_arch(&raw_arch32_, 1, NX_LittleEndian);
+        }
+        object_offset = raw_arch32_.offset;
+        object_size = raw_arch32_.size;
     }
 
-    void *mach_offset = (char *)(ctx_->file_start) + data_.offset;
+    if (object_offset > ctx_->file_size || object_size > ctx_->file_size - object_offset) {
+        throw NodeException("Malformed Fat Mach-O: arch range exceeds file size");
+    }
+    if (object_size < sizeof(uint32_t)) {
+        throw NodeException("Malformed Fat Mach-O: arch payload too small");
+    }
+
+    void *mach_offset = reinterpret_cast<char *>(ctx_->file_start) + object_offset;
     mh_ = std::make_shared<MachHeader>();
     mh_->Init(mach_offset,ctx_);
 }
 
 std::string FatArch::GetCpuTypeString()
 {
-    return util::GetCpuTypeString(this->data().cputype);
+    return util::GetCpuTypeString(cpu_type());
 }
 
 std::string FatArch::GetCpuSubTypeString()
 {
-    return util::GetCpuSubTypeString(this->data().cputype, this->data().cpusubtype);
+    return util::GetCpuSubTypeString(cpu_type(), cpu_subtype());
 }
 
 
@@ -36,9 +59,24 @@ void FatHeader::Init(void *offset, NodeContextPtr &ctx) {
     NodeData::Init(offset,ctx);
 
     bool swap = false;
-    if(data_.magic == FAT_CIGAM){
+    if(data_.magic == FAT_CIGAM || data_.magic == FAT_CIGAM_64){
         swap = true;
         qv_swap_fat_header(& data_,NX_LittleEndian);
+    }
+
+    const bool fat64 = data_.magic == FAT_MAGIC_64;
+    const uint64_t base = reinterpret_cast<uint64_t>(offset_) - reinterpret_cast<uint64_t>(ctx_->file_start);
+    if (base > ctx_->file_size || ctx_->file_size - base < sizeof(qv_fat_header)) {
+        throw NodeException("Malformed Fat Mach-O: header exceeds file size");
+    }
+
+    const uint64_t arch_entry_size = fat64 ? sizeof(qv_fat_arch_64) : sizeof(qv_fat_arch);
+    const uint64_t arch_table_size = static_cast<uint64_t>(data_.nfat_arch) * arch_entry_size;
+    if (data_.nfat_arch > 0 && arch_table_size / arch_entry_size != data_.nfat_arch) {
+        throw NodeException("Malformed Fat Mach-O: nfat_arch overflow");
+    }
+    if (ctx_->file_size - base - sizeof(qv_fat_header) < arch_table_size) {
+        throw NodeException("Malformed Fat Mach-O: arch table exceeds file size");
     }
 
     char * arch_offset = (char*)offset_ + sizeof(qv_fat_header);
@@ -46,7 +84,8 @@ void FatHeader::Init(void *offset, NodeContextPtr &ctx) {
     for(uint32_t i = 0; i < data_.nfat_arch; ++i){
         auto arch = std::make_shared<FatArch>();
         arch->set_swap(swap);
-        arch->Init(arch_offset + i * FatArch::DATA_SIZE(),ctx);
+        arch->set_is_fat64(fat64);
+        arch->Init(arch_offset + i * arch_entry_size,ctx);
 
         archs_.push_back(arch);
     }

--- a/src/libmoex/node/FatHeader.h
+++ b/src/libmoex/node/FatHeader.h
@@ -16,13 +16,32 @@ private:
     MachHeaderPtr mh_;
 
     bool swap_ = false;
+    bool is_fat64_ = false;
+
+    qv_fat_arch raw_arch32_{};
+    qv_fat_arch_64 raw_arch64_{};
 public:
+    static constexpr std::size_t DATA_SIZE32(){ return sizeof(qv_fat_arch); }
+    static constexpr std::size_t DATA_SIZE64(){ return sizeof(qv_fat_arch_64); }
+
     void set_swap(bool swap){swap_ = swap;}
+    void set_is_fat64(bool is_fat64){is_fat64_ = is_fat64;}
     MachHeaderPtr & mh(){return mh_;}
 
     void Init(void *offset,NodeContextPtr &ctx) override;
 
-    bool Is64()const{ return mh_->Is64(); }
+    bool Is64()const{ return mh_ && mh_->Is64(); }
+    bool IsFat64()const{ return is_fat64_; }
+    std::size_t EntrySize() const { return is_fat64_ ? DATA_SIZE64() : DATA_SIZE32(); }
+
+    const qv_fat_arch *offset32() const { return is_fat64_ ? nullptr : static_cast<const qv_fat_arch *>(offset_); }
+    const qv_fat_arch_64 *offset64() const { return is_fat64_ ? reinterpret_cast<const qv_fat_arch_64 *>(offset_) : nullptr; }
+
+    qv_cpu_type_t cpu_type() const { return is_fat64_ ? raw_arch64_.cputype : raw_arch32_.cputype; }
+    qv_cpu_subtype_t cpu_subtype() const { return is_fat64_ ? raw_arch64_.cpusubtype : raw_arch32_.cpusubtype; }
+    uint64_t offset_value() const { return is_fat64_ ? raw_arch64_.offset : raw_arch32_.offset; }
+    uint64_t size_value() const { return is_fat64_ ? raw_arch64_.size : raw_arch32_.size; }
+    uint32_t align_value() const { return is_fat64_ ? raw_arch64_.align : raw_arch32_.align; }
 
     std::string GetCpuTypeString();
     std::string GetCpuSubTypeString();

--- a/src/libmoex/node/Magic.h
+++ b/src/libmoex/node/Magic.h
@@ -31,7 +31,8 @@ public:
 
     // Whether it is Fat binary
     bool IsFat(){
-        return magic_ == FAT_MAGIC || magic_ == FAT_CIGAM;
+        return magic_ == FAT_MAGIC || magic_ == FAT_CIGAM ||
+               magic_ == FAT_MAGIC_64 || magic_ == FAT_CIGAM_64;
     }
 
     // Whether it is 64 bit arch

--- a/src/libmoex/node/qvmacho/qvmacho.h
+++ b/src/libmoex/node/qvmacho/qvmacho.h
@@ -283,6 +283,15 @@ struct qv_fat_arch {
 #define FAT_MAGIC_64	0xcafebabf
 #define FAT_CIGAM_64	0xbfbafeca	/* NXSwapLong(FAT_MAGIC_64) */
 
+struct qv_fat_arch_64 {
+    qv_cpu_type_t    cputype;     /* cpu specifier (int) */
+    qv_cpu_subtype_t cpusubtype;  /* machine specifier (int) */
+    uint64_t         offset;      /* file offset to this object file */
+    uint64_t         size;        /* size of this object file */
+    uint32_t         align;       /* alignment as a power of 2 */
+    uint32_t         reserved;    /* reserved */
+};
+
 
 /*
  * The 32-bit mach header appears at the very beginning of the object file for
@@ -373,6 +382,18 @@ enum NXByteOrder {
 
 #define OSSwapInt32(x) OSSwapConstInt32(x)
 
+#define OSSwapConstInt64(x) \
+    ((uint64_t)((((uint64_t)(x) & 0xff00000000000000ULL) >> 56) | \
+                (((uint64_t)(x) & 0x00ff000000000000ULL) >> 40) | \
+                (((uint64_t)(x) & 0x0000ff0000000000ULL) >> 24) | \
+                (((uint64_t)(x) & 0x000000ff00000000ULL) >>  8) | \
+                (((uint64_t)(x) & 0x00000000ff000000ULL) <<  8) | \
+                (((uint64_t)(x) & 0x0000000000ff0000ULL) << 24) | \
+                (((uint64_t)(x) & 0x000000000000ff00ULL) << 40) | \
+                (((uint64_t)(x) & 0x00000000000000ffULL) << 56)))
+
+#define OSSwapInt64(x) OSSwapConstInt64(x)
+
 
 inline void
 qv_swap_fat_arch(
@@ -399,6 +420,23 @@ enum NXByteOrder target_byte_sex)
 {
     fat_header->magic     = OSSwapInt32(fat_header->magic);
     fat_header->nfat_arch = OSSwapInt32(fat_header->nfat_arch);
+}
+
+inline void
+qv_swap_fat_arch_64(
+struct qv_fat_arch_64 *fat_archs,
+uint32_t nfat_arch,
+enum NXByteOrder target_byte_sex)
+{
+    uint32_t i;
+    for (i = 0; i < nfat_arch; i++) {
+        fat_archs[i].cputype = OSSwapInt32(fat_archs[i].cputype);
+        fat_archs[i].cpusubtype = OSSwapInt32(fat_archs[i].cpusubtype);
+        fat_archs[i].offset = OSSwapInt64(fat_archs[i].offset);
+        fat_archs[i].size = OSSwapInt64(fat_archs[i].size);
+        fat_archs[i].align = OSSwapInt32(fat_archs[i].align);
+        fat_archs[i].reserved = OSSwapInt32(fat_archs[i].reserved);
+    }
 }
 
 inline

--- a/src/libmoex/viewnode/views/FatHeaderViewNode.cpp
+++ b/src/libmoex/viewnode/views/FatHeaderViewNode.cpp
@@ -35,12 +35,25 @@ void FatHeaderViewNode::InitViewDatas(){
         t->AddSeparator();
 
         for(auto & arch : d_->archs()){
-            const qv_fat_arch * a = arch->offset();
-            t->AddRow(a->cputype,"CPU Type",arch->GetCpuTypeString());
-            t->AddRow(a->cpusubtype,"CPU SubType",arch->GetCpuSubTypeString());
-            t->AddRow(a->offset,"Offset",AsString(arch->data().offset));
-            t->AddRow(a->size,"Size",AsString(arch->data().size));
-            t->AddRow(a->align,"Align",AsString(1 << arch->data().align)); // why 1<<
+            if (arch->IsFat64()) {
+                const qv_fat_arch_64 *a = arch->offset64();
+                t->AddRow(a->cputype,"CPU Type",arch->GetCpuTypeString());
+                t->AddRow(a->cpusubtype,"CPU SubType",arch->GetCpuSubTypeString());
+                t->AddRow(a->offset,"Offset",AsShortHexString(arch->offset_value()));
+                t->AddRow(a->size,"Size",AsShortHexString(arch->size_value()));
+                const uint32_t align = arch->align_value();
+                const uint64_t align_value = (align < 63) ? (1ULL << align) : 0;
+                t->AddRow(a->align,"Align",align_value == 0 ? AsString(align) : AsString(align_value));
+            } else {
+                const qv_fat_arch *a = arch->offset32();
+                t->AddRow(a->cputype,"CPU Type",arch->GetCpuTypeString());
+                t->AddRow(a->cpusubtype,"CPU SubType",arch->GetCpuSubTypeString());
+                t->AddRow(a->offset,"Offset",AsShortHexString(arch->offset_value()));
+                t->AddRow(a->size,"Size",AsShortHexString(arch->size_value()));
+                const uint32_t align = arch->align_value();
+                const uint64_t align_value = (align < 63) ? (1ULL << align) : 0;
+                t->AddRow(a->align,"Align",align_value == 0 ? AsString(align) : AsString(align_value));
+            }
 
             t->AddSeparator();
         }
@@ -52,7 +65,7 @@ void FatHeaderViewNode::InitViewDatas(){
         b->offset = (char*)d_->offset();
         b->size = d_->DATA_SIZE();
         for(auto & arch: d_->archs()){
-            b->size += arch->DATA_SIZE();
+            b->size += arch->EntrySize();
         }
         b->start_value = (uint64_t)b->offset - (uint64_t)d_->ctx()->file_start;
     }

--- a/tests/regression/run_crash_regression.sh
+++ b/tests/regression/run_crash_regression.sh
@@ -47,11 +47,30 @@ printf '\x60\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' | dd o
 printf '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
   | dd of="${bad_map}" bs=1 seek=96 conv=notrunc 2>/dev/null
 
+# Valid minimal FAT64 with one x86_64 MH_MAGIC_64 image at offset 0x1000.
+valid_fat64="${TMP_DIR}/valid_fat64.bin"
+truncate -s 4096 "${valid_fat64}"
+printf '\xca\xfe\xba\xbf\x00\x00\x00\x01' \
+  | dd of="${valid_fat64}" bs=1 seek=0 conv=notrunc 2>/dev/null
+printf '\x01\x00\x00\x07\x00\x00\x00\x03' \
+  | dd of="${valid_fat64}" bs=1 seek=8 conv=notrunc 2>/dev/null
+printf '\x00\x00\x00\x00\x00\x00\x10\x00' \
+  | dd of="${valid_fat64}" bs=1 seek=16 conv=notrunc 2>/dev/null
+printf '\x00\x00\x00\x00\x00\x00\x00\x20' \
+  | dd of="${valid_fat64}" bs=1 seek=24 conv=notrunc 2>/dev/null
+printf '\x00\x00\x00\x0c\x00\x00\x00\x00' \
+  | dd of="${valid_fat64}" bs=1 seek=32 conv=notrunc 2>/dev/null
+printf '\xcf\xfa\xed\xfe\x07\x00\x00\x01\x03\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
+  | dd of="${valid_fat64}" bs=1 seek=4096 conv=notrunc 2>/dev/null
+
 FAIL=0
 TOTAL=0
 REJECTED=0
 ACCEPTED=0
 for f in "${TMP_DIR}"/*; do
+  if [[ "$(basename "${f}")" == "valid_fat64.bin" ]]; then
+    continue
+  fi
   TOTAL=$((TOTAL + 1))
   set +e
   "${PARSER_BIN}" "${f}" >/dev/null 2>&1
@@ -72,6 +91,17 @@ for f in "${TMP_DIR}"/*; do
     echo "[ok] malformed input rejected safely: $(basename "${f}")"
   fi
 done
+
+set +e
+"${PARSER_BIN}" "${valid_fat64}" >/dev/null 2>&1
+valid_rc=$?
+set -e
+if [[ "${valid_rc}" -ne 0 ]]; then
+  echo "[fail] valid FAT64 should parse successfully: ${valid_fat64}"
+  FAIL=1
+else
+  echo "[ok] valid FAT64 parsed successfully: $(basename "${valid_fat64}")"
+fi
 
 if [[ "${FAIL}" -ne 0 ]]; then
   echo "crash-regression: failed"


### PR DESCRIPTION
This PR addresses all currently open issues in one batch, focusing on parser safety, FAT/FAT64 compatibility, and macOS packaging metadata.

## What changed
- Added full FAT64 recognition and parsing (FAT_MAGIC_64 / FAT_CIGAM_64).
- Added qv_fat_arch_64 structure and byte-swap support.
- Hardened fat-arch bounds validation to prevent out-of-range access and malformed input crashes.
- Updated Fat Header view to correctly display 64-bit arch offsets/sizes in hex.
- Added crash-regression coverage with a generated valid minimal FAT64 sample.
- Added macOS bundle version properties in CMake (CFBundleVersion / CFBundleShortVersionString).
- Added NSRequiresAquaSystemAppearance=false in release Info.plist generation for dark mode compatibility.

## Validation
- cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/Users/eevv/Qt/6.10.2/macos"
- cmake --build build -j8
- tests/regression/run_all.sh (passed)

Closes #6
Closes #17
Closes #21
Closes #23
Closes #24
Closes #25
